### PR TITLE
docs(*): fix docs on recently deprecated properties/methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,17 @@
 
 ## Deprecation Notices
 
-- Deprecated ~~`aHrefSanitizationWhitelist`~~. It is now `aHrefSanitizationTrustedUri`
-- Deprecated ~~`imgSrcSanitizationWhitelist`~~. It is now `imgSrcSanitizationTrustedUri`
-- Deprecated ~~`xsrfWhitelistedOrigins`~~. It is now `xsrfTrustedOrigins`
-- Deprecated ~~`resourceUrlWhitelist`~~. It is now `trustedResourceUrlList`
-- Deprecated ~~`resourceUrlBlacklist`~~. It is now `bannedResourceUrlList`
+- Deprecated ~~`$compileProvider.aHrefSanitizationWhitelist`~~.
+  It is now [aHrefSanitizationTrustedUrlList](https://docs.angularjs.org/api/ng/provider/$compileProvider#aHrefSanitizationTrustedUrlList)`.
+- Deprecated ~~`$compileProvider.imgSrcSanitizationWhitelist`~~.
+  It is now [imgSrcSanitizationTrustedUrlList](https://docs.angularjs.org/api/ng/provider/$compileProvider#imgSrcSanitizationTrustedUrlList).
+- Deprecated ~~`$httpProvider.xsrfWhitelistedOrigins`~~.
+  It is now [xsrfTrustedOrigins](https://docs.angularjs.org/api/ng/provider/$httpProvider#xsrfTrustedOrigins).
+- Deprecated ~~`$sceDelegateProvider.resourceUrlWhitelist`~~.
+  It is now [trustedResourceUrlList](https://docs.angularjs.org/api/ng/provider/$sceDelegateProvider#trustedResourceUrlList).
+- Deprecated ~~`$sceDelegateProvider.resourceUrlBlacklist`~~.
+  It is now [bannedResourceUrlList](https://docs.angularjs.org/api/ng/provider/$sceDelegateProvider#bannedResourceUrlList).
+
 
 For the purposes of backward compatibility, the previous symbols are aliased to their new symbol.
 

--- a/src/ul/compile.js
+++ b/src/ul/compile.js
@@ -1734,15 +1734,15 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
    * @deprecated
    * sinceVersion="1.8.1"
    *
-   * This function is deprecated. Use {@link $compileProvider#aHrefSanitizationTrustedUrlList
+   * This method is deprecated. Use {@link $compileProvider#aHrefSanitizationTrustedUrlList
    * aHrefSanitizationTrustedUrlList} instead.
    */
   Object.defineProperty(this, 'aHrefSanitizationWhitelist', {
     get: function() {
       return this.aHrefSanitizationTrustedUrlList;
     },
-    set: function(regexp) {
-      this.aHrefSanitizationTrustedUrlList = regexp;
+    set: function(value) {
+      this.aHrefSanitizationTrustedUrlList = value;
     }
   });
 
@@ -1785,15 +1785,15 @@ function $CompileProvider($provide, $$sanitizeUriProvider) {
    * @deprecated
    * sinceVersion="1.8.1"
    *
-   * This function is deprecated. Use {@link $compileProvider#imgSrcSanitizationTrustedUrlList
+   * This method is deprecated. Use {@link $compileProvider#imgSrcSanitizationTrustedUrlList
    * imgSrcSanitizationTrustedUrlList} instead.
    */
   Object.defineProperty(this, 'imgSrcSanitizationWhitelist', {
     get: function() {
       return this.imgSrcSanitizationTrustedUrlList;
     },
-    set: function(regexp) {
-      this.imgSrcSanitizationTrustedUrlList = regexp;
+    set: function(value) {
+      this.imgSrcSanitizationTrustedUrlList = value;
     }
   });
 

--- a/src/ul/http.js
+++ b/src/ul/http.js
@@ -436,7 +436,7 @@ function $HttpProvider() {
    * @deprecated
    * sinceVersion="1.8.1"
    *
-   * This function is deprecated. Use {@link $httpProvider#xsrfTrustedOrigins xsrfTrustedOrigins}
+   * This property is deprecated. Use {@link $httpProvider#xsrfTrustedOrigins xsrfTrustedOrigins}
    * instead.
    */
   Object.defineProperty(this, 'xsrfWhitelistedOrigins', {

--- a/src/ul/sce.js
+++ b/src/ul/sce.js
@@ -258,7 +258,7 @@ function $SceDelegateProvider() {
    * @deprecated
    * sinceVersion="1.8.1"
    *
-   * This function is deprecated. Use {@link $sceDelegateProvider#bannedResourceUrlList
+   * This method is deprecated. Use {@link $sceDelegateProvider#bannedResourceUrlList
    * bannedResourceUrlList} instead.
    */
   Object.defineProperty(this, 'resourceUrlBlacklist', {


### PR DESCRIPTION
In commits 9679e58ec4e9d9e4b743..3dd42cea688a7b6f7789, some properties
and methods names including the terms whitelist/blacklist were
deprecated in favor of new ones not including the terms.

This commit fixes some typos in docs related to these changes and adds
links to the new properties/methods in the changelog for easier access.

Fixes #30
